### PR TITLE
refactor: use type alias for CommandDialogProps

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (


### PR DESCRIPTION
## Summary
- replace CommandDialogProps interface with type alias

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: existing lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68a4cb8a4354832fba1ce6717ef51094