### PR TITLE
refactor: use type alias for textarea props

### DIFF
--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {


### PR DESCRIPTION
## Summary
- replace TextareaProps interface with type alias

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, no-case-declarations, @typescript-eslint/no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cb8c77bc832f8dd109ab1851ce86