### PR TITLE
feat: add waha service config

### DIFF
--- a/.env
+++ b/.env
@@ -13,6 +13,7 @@ VITE_FLOWISE_URL=https://flowise.okta-solutions.com
 VITE_WEBUI_URL=https://webui.okta-solutions.com
 VITE_KEYCLOAK_ADMIN_URL=https://keycloak.okta-solutions.com/auth
 VITE_QDRANT_URL=https://qdrant.okta-solutions.com/dashboard/
+VITE_WAHA_URL=https://wa.okta-solutions.cpm/dashboard
 VITE_BOLT_URL=https://bolt.okta-solutions.com/
 
 # General Settings
@@ -29,4 +30,5 @@ VITE_FLOWISE_VERSION=1.4.3
 VITE_WEBUI_VERSION=1.2.1
 VITE_KEYCLOAK_VERSION=23.0.0
 VITE_QDRANT_VERSION=1.7.0
+VITE_WAHA_VERSION=1.0.0
 VITE_BOLT_VERSION=1.0.0

--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,11 @@ VITE_FLOWISE_URL=https://flowise.your-domain.com
 VITE_WEBUI_URL=https://webui.your-domain.com
 VITE_KEYCLOAK_ADMIN_URL=https://keycloak.your-domain.com
 VITE_QDRANT_URL=https://qdrant.your-domain.com
+VITE_WAHA_URL=https://waha.your-domain.com
 
 # General Settings
 VITE_APP_TITLE=Корпоративные Сервисы
 VITE_DEFAULT_DEV_MODE=true
+
+# Service Versions
+VITE_WAHA_VERSION=1.0.0

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -39,6 +39,7 @@ export const serviceUrls = {
   webui: getEnvVar('VITE_WEBUI_URL'),
   keycloakAdmin: getEnvVar('VITE_KEYCLOAK_ADMIN_URL'),
   qdrant: getEnvVar('VITE_QDRANT_URL'),
+  waha: getEnvVar('VITE_WAHA_URL'),
   bolt: getEnvVar('VITE_BOLT_URL'),
 } as const;
 
@@ -52,6 +53,7 @@ export const serviceVersions = {
   webui: getEnvVar('VITE_WEBUI_VERSION', ''),
   keycloakAdmin: getEnvVar('VITE_KEYCLOAK_VERSION', '23.0.0'),
   qdrant: getEnvVar('VITE_QDRANT_VERSION', '1.7.0'),
+  waha: getEnvVar('VITE_WAHA_VERSION', '1.0.0'),
   bolt: getEnvVar('VITE_BOLT_VERSION', '1.0.0'),
 } as const;
 

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -14,10 +14,14 @@ interface ImportMetaEnv {
   readonly VITE_PROMETHEUS_URL: string;
   readonly VITE_FLOWISE_URL: string;
   readonly VITE_WEBUI_URL: string;
-  
+  readonly VITE_WAHA_URL: string;
+
   // General Settings
   readonly VITE_APP_TITLE: string;
   readonly VITE_DEFAULT_DEV_MODE: string;
+
+  // Service Versions
+  readonly VITE_WAHA_VERSION: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- expose WAHA service URL and version
- type WAHA env variables
- document WAHA env settings

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, Unexpected lexical declaration in case block, A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f90cd6fc832f854024c08a4a27b7