### PR TITLE
Add WAHA service card without SSO

### DIFF
--- a/.env
+++ b/.env
@@ -14,6 +14,7 @@ VITE_WEBUI_URL=https://webui.okta-solutions.com
 VITE_KEYCLOAK_ADMIN_URL=https://keycloak.okta-solutions.com/auth
 VITE_QDRANT_URL=https://qdrant.okta-solutions.com/dashboard/
 VITE_BOLT_URL=https://bolt.okta-solutions.com/
+VITE_WAHA_URL=https://waha.okta-solutions.com
 
 # General Settings
 VITE_APP_TITLE=OKTA Solutions Platform
@@ -30,3 +31,4 @@ VITE_WEBUI_VERSION=1.2.1
 VITE_KEYCLOAK_VERSION=23.0.0
 VITE_QDRANT_VERSION=1.7.0
 VITE_BOLT_VERSION=1.0.0
+VITE_WAHA_VERSION=1.0.0

--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ VITE_FLOWISE_URL=https://flowise.your-domain.com
 VITE_WEBUI_URL=https://webui.your-domain.com
 VITE_KEYCLOAK_ADMIN_URL=https://keycloak.your-domain.com
 VITE_QDRANT_URL=https://qdrant.your-domain.com
+VITE_WAHA_URL=https://waha.your-domain.com
 
 # General Settings
 VITE_APP_TITLE=Корпоративные Сервисы

--- a/src/components/ServicesGrid.tsx
+++ b/src/components/ServicesGrid.tsx
@@ -104,6 +104,17 @@ const SERVICES: Service[] = [
     status: 'online',
     version: env.versions.qdrant,
     ssoEnabled: true
+  },
+  {
+    id: 'waha',
+    name: 'WAHA',
+    description: 'Интеграция с WhatsApp через WAHA',
+    url: env.services.waha,
+    icon: <Code className="h-5 w-5" />,
+    category: 'Коммуникации',
+    status: 'online',
+    version: env.versions.waha,
+    ssoEnabled: false
   }
 ];
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -40,6 +40,7 @@ export const serviceUrls = {
   keycloakAdmin: getEnvVar('VITE_KEYCLOAK_ADMIN_URL'),
   qdrant: getEnvVar('VITE_QDRANT_URL'),
   bolt: getEnvVar('VITE_BOLT_URL'),
+  waha: getEnvVar('VITE_WAHA_URL'),
 } as const;
 
 // Service Versions
@@ -53,6 +54,7 @@ export const serviceVersions = {
   keycloakAdmin: getEnvVar('VITE_KEYCLOAK_VERSION', '23.0.0'),
   qdrant: getEnvVar('VITE_QDRANT_VERSION', '1.7.0'),
   bolt: getEnvVar('VITE_BOLT_VERSION', '1.0.0'),
+  waha: getEnvVar('VITE_WAHA_VERSION', '1.0.0'),
 } as const;
 
 // General Settings

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -14,6 +14,7 @@ interface ImportMetaEnv {
   readonly VITE_PROMETHEUS_URL: string;
   readonly VITE_FLOWISE_URL: string;
   readonly VITE_WEBUI_URL: string;
+  readonly VITE_WAHA_URL: string;
   
   // General Settings
   readonly VITE_APP_TITLE: string;


### PR DESCRIPTION
## Summary
- add WAHA service configuration and environment variables
- register WAHA in services grid with SSO disabled

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected lexical declaration in case block, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f9144c74832facc4e4eb5141a47b