### PR TITLE
Add missing Nextcloud env variable

### DIFF
--- a/.env
+++ b/.env
@@ -11,9 +11,11 @@ VITE_SUPABASE_URL=https://supabase.okta-solutions.com
 VITE_PROMETHEUS_URL=https://prometheus.okta-solutions.com
 VITE_FLOWISE_URL=https://flowise.okta-solutions.com
 VITE_WEBUI_URL=https://webui.okta-solutions.com
+VITE_NEXTCLOUD_URL=https://fs.okta-solutions.com/
 VITE_KEYCLOAK_ADMIN_URL=https://keycloak.okta-solutions.com/auth
 VITE_QDRANT_URL=https://qdrant.okta-solutions.com/dashboard/
 VITE_WAHA_URL=https://wa.okta-solutions.cpm/dashboard
+VITE_MATRIX_URL=https://element.okta-solutions.com/
 VITE_BOLT_URL=https://bolt.okta-solutions.com/
 
 # General Settings


### PR DESCRIPTION
## Summary
- define `VITE_NEXTCLOUD_URL` and `VITE_MATRIX_URL` in `.env`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68af3a315194832fbd788963db908e92