### PR TITLE
Use direct links for Nextcloud and Matrix

### DIFF
--- a/src/components/ServicesGrid.tsx
+++ b/src/components/ServicesGrid.tsx
@@ -115,7 +115,7 @@ const SERVICES: Service[] = [
     category: 'Файлы',
     status: 'online',
     version: env.versions.nextcloud,
-    ssoEnabled: true
+    ssoEnabled: false
   },
   {
     id: 'waha',
@@ -139,7 +139,7 @@ const SERVICES: Service[] = [
     category: 'Омниканальность',
     status: 'online',
     version: env.versions.matrix,
-    ssoEnabled: true
+    ssoEnabled: false
   }
 ];
 

--- a/src/hooks/useSSO.ts
+++ b/src/hooks/useSSO.ts
@@ -52,23 +52,11 @@ const SSO_CONFIGS: Record<string, SSOConfig> = {
     method: 'oauth2',
     requiresProxy: false // Same Keycloak instance - shared session
   },
-  'nextcloud': {
-    id: 'nextcloud',
-    method: 'oauth2',
-    requiresProxy: false,
-    authEndpoint: '/apps/oauth2/authorize'
-  },
   'qdrant': {
     id: 'qdrant',
     method: 'token_url',
     tokenParam: 'api-key', // Try API key approach
     requiresProxy: false
-  },
-  'matrix': {
-    id: 'matrix',
-    method: 'oauth2',
-    requiresProxy: false,
-    authEndpoint: '/_matrix/client/r0/login/sso/redirect'
   }
 };
 

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -28,7 +28,7 @@ interface ImportMetaEnv {
   readonly VITE_MATRIX_VERSION: string;
 
   readonly VITE_NEXTCLOUD_VERSION: string;
-
+}
 
 interface ImportMeta {
   readonly env: ImportMetaEnv;


### PR DESCRIPTION
## Summary
- disable SSO for Nextcloud and Matrix to open them via direct links
- remove unused SSO config entries
- fix ImportMetaEnv type definition

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af3ec6a4c8832fb097ef430ba3e94a