### PR TITLE
feat: add Baserow service

### DIFF
--- a/.env
+++ b/.env
@@ -14,6 +14,7 @@ VITE_WEBUI_URL=https://webui.okta-solutions.com
 VITE_NEXTCLOUD_URL=https://fs.okta-solutions.com/
 VITE_KEYCLOAK_ADMIN_URL=https://keycloak.okta-solutions.com/auth
 VITE_QDRANT_URL=https://qdrant.okta-solutions.com/dashboard/
+VITE_BASEROW_URL=https://baserow.okta-solutions.com/
 VITE_WAHA_URL=https://wa.okta-solutions.cpm/dashboard
 VITE_MATRIX_URL=https://element.okta-solutions.com/
 VITE_BOLT_URL=https://bolt.okta-solutions.com/
@@ -32,5 +33,7 @@ VITE_FLOWISE_VERSION=1.4.3
 VITE_WEBUI_VERSION=1.2.1
 VITE_KEYCLOAK_VERSION=23.0.0
 VITE_QDRANT_VERSION=1.7.0
+VITE_BASEROW_VERSION=1.0.0
 VITE_WAHA_VERSION=1.0.0
 VITE_BOLT_VERSION=1.0.0
+

--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ VITE_WEBUI_URL=https://webui.your-domain.com
 VITE_NEXTCLOUD_URL=https://fs.okta-solutions.com/
 VITE_KEYCLOAK_ADMIN_URL=https://keycloak.your-domain.com
 VITE_QDRANT_URL=https://qdrant.your-domain.com
+VITE_BASEROW_URL=https://baserow.your-domain.com
 VITE_WAHA_URL=https://waha.your-domain.com
 VITE_MATRIX_URL=https://element.okta-solutions.com/
 
@@ -25,4 +26,5 @@ VITE_DEFAULT_DEV_MODE=true
 VITE_WAHA_VERSION=1.0.0
 VITE_MATRIX_VERSION=1.0.0
 VITE_NEXTCLOUD_VERSION=24.0.0
+VITE_BASEROW_VERSION=1.0.0
 

--- a/src/components/ServicesGrid.tsx
+++ b/src/components/ServicesGrid.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { motion } from 'framer-motion';
 import ServiceCard, { Service } from './ServiceCard';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Bot, Database, Activity, Zap, BarChart3, Globe, Shield, Cpu, Code, MessageSquare, Cloud } from 'lucide-react';
+import { Bot, Database, Activity, Zap, BarChart3, Globe, Shield, Cpu, Code, MessageSquare, Cloud, Table } from 'lucide-react';
 import { env } from '@/lib/env';
 import grafanaLogo from '@/assets/service-icons/grafana-original.svg';
 import supabaseLogo from '@/assets/service-icons/supabase-original.png';
@@ -104,6 +104,18 @@ const SERVICES: Service[] = [
     status: 'online',
     version: env.versions.qdrant,
     ssoEnabled: true
+  },
+  {
+    id: 'baserow',
+    name: 'Baserow',
+    description: 'Профессиональная платформа для управления данными и организации совместных процессов в формате онлайн-таблиц',
+    url: env.services.baserow,
+    logo: '/uploads/a3f7c9e2.png',
+    icon: <Table className="h-5 w-5" />,
+    category: 'Данные',
+    status: 'online',
+    version: env.versions.baserow,
+    ssoEnabled: false
   },
   {
     id: 'nextcloud',

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -43,6 +43,7 @@ export const serviceUrls = {
   maubot: getEnvVar('VITE_MAUBOT_URL', 'https://maubot.okta-solutions.com/_matrix/maubot/#/'),
   keycloakAdmin: getEnvVar('VITE_KEYCLOAK_ADMIN_URL'),
   qdrant: getEnvVar('VITE_QDRANT_URL'),
+  baserow: getEnvVar('VITE_BASEROW_URL'),
   bolt: getEnvVar('VITE_BOLT_URL'),
 } as const;
 
@@ -60,6 +61,7 @@ export const serviceVersions = {
   maubot: getEnvVar('VITE_MAUBOT_VERSION', '1.0.0'),
   keycloakAdmin: getEnvVar('VITE_KEYCLOAK_VERSION', '23.0.0'),
   qdrant: getEnvVar('VITE_QDRANT_VERSION', '1.7.0'),
+  baserow: getEnvVar('VITE_BASEROW_VERSION', '1.0.0'),
   bolt: getEnvVar('VITE_BOLT_VERSION', '1.0.0'),
 } as const;
 

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -18,6 +18,7 @@ interface ImportMetaEnv {
   readonly VITE_WAHA_URL: string;
   readonly VITE_MATRIX_URL: string;
   readonly VITE_MAUBOT_URL: string;
+  readonly VITE_BASEROW_URL: string;
 
   // General Settings
   readonly VITE_APP_TITLE: string;
@@ -31,6 +32,7 @@ interface ImportMetaEnv {
   readonly VITE_MAUBOT_VERSION: string;
 
   readonly VITE_NEXTCLOUD_VERSION: string;
+  readonly VITE_BASEROW_VERSION: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- integrate Baserow service with logo and link in the dashboard
- expose Baserow configuration via environment variables

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af6a7558fc832fbe1e9457f0d45262