### PR TITLE
Add jambonz telephony platform to services catalog

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ VITE_NEXTCLOUD_URL=https://fs.okta-solutions.com/
 VITE_KEYCLOAK_ADMIN_URL=https://keycloak.your-domain.com
 VITE_QDRANT_URL=https://qdrant.your-domain.com
 VITE_BASEROW_URL=https://baserow.your-domain.com
+VITE_JAMBONZ_URL=https://jambonz-portal.okta-solutions.com/
 VITE_WAHA_URL=https://waha.your-domain.com
 VITE_MATRIX_URL=https://element.okta-solutions.com/
 
@@ -27,4 +28,5 @@ VITE_WAHA_VERSION=1.0.0
 VITE_MATRIX_VERSION=1.0.0
 VITE_NEXTCLOUD_VERSION=24.0.0
 VITE_BASEROW_VERSION=1.0.0
+VITE_JAMBONZ_VERSION=1.0.0
 

--- a/src/components/ServicesGrid.tsx
+++ b/src/components/ServicesGrid.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { motion } from 'framer-motion';
 import ServiceCard, { Service } from './ServiceCard';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Bot, Database, Activity, Zap, BarChart3, Globe, Shield, Cpu, Code, MessageSquare, Cloud, Table } from 'lucide-react';
+import { Bot, Database, Activity, Zap, BarChart3, Globe, Shield, Cpu, Code, MessageSquare, Cloud, Table, PhoneCall } from 'lucide-react';
 import { env } from '@/lib/env';
 import grafanaLogo from '@/assets/service-icons/grafana-original.svg';
 import supabaseLogo from '@/assets/service-icons/supabase-original.png';
@@ -107,6 +107,18 @@ const SERVICES: Service[] = [
     category: 'Данные',
     status: 'online',
     version: env.versions.baserow
+  },
+  {
+    id: 'jambonz',
+    name: 'jambonz',
+    description:
+      'SIP-платформа с API для звонков и коннектором к AI (TTS/STT). Превращает звонки в HTTP/WS-события для автоматизации через n8n и ваши сервисы.',
+    url: env.services.jambonz,
+    logo: '/uploads/b0cd15b3-f2a6-4ba5-92e4-9e6d492fe99c.png',
+    icon: <PhoneCall className="h-5 w-5" />,
+    category: 'Телефония',
+    status: 'online',
+    version: env.versions.jambonz
   },
   {
     id: 'nextcloud',

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -36,6 +36,7 @@ export const serviceUrls = {
   keycloakAdmin: getEnvVar('VITE_KEYCLOAK_ADMIN_URL'),
   qdrant: getEnvVar('VITE_QDRANT_URL'),
   baserow: getEnvVar('VITE_BASEROW_URL'),
+  jambonz: getEnvVar('VITE_JAMBONZ_URL', 'https://jambonz-portal.okta-solutions.com/'),
   bolt: getEnvVar('VITE_BOLT_URL'),
 } as const;
 
@@ -54,6 +55,7 @@ export const serviceVersions = {
   keycloakAdmin: getEnvVar('VITE_KEYCLOAK_VERSION', '23.0.0'),
   qdrant: getEnvVar('VITE_QDRANT_VERSION', '1.7.0'),
   baserow: getEnvVar('VITE_BASEROW_VERSION', '1.0.0'),
+  jambonz: getEnvVar('VITE_JAMBONZ_VERSION', '1.0.0'),
   bolt: getEnvVar('VITE_BOLT_VERSION', '1.0.0'),
 } as const;
 

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -13,20 +13,31 @@ interface ImportMetaEnv {
   readonly VITE_MATRIX_URL: string;
   readonly VITE_MAUBOT_URL: string;
   readonly VITE_BASEROW_URL: string;
+  readonly VITE_KEYCLOAK_ADMIN_URL: string;
+  readonly VITE_QDRANT_URL: string;
+  readonly VITE_JAMBONZ_URL: string;
+  readonly VITE_BOLT_URL: string;
 
   // General Settings
   readonly VITE_APP_TITLE: string;
   readonly VITE_DEFAULT_DEV_MODE: string;
 
   // Service Versions
-  readonly VITE_WAHA_VERSION: string;
-
-  readonly VITE_MATRIX_VERSION: string;
-
-  readonly VITE_MAUBOT_VERSION: string;
-
+  readonly VITE_N8N_VERSION: string;
+  readonly VITE_GRAFANA_VERSION: string;
+  readonly VITE_SUPABASE_VERSION: string;
+  readonly VITE_PROMETHEUS_VERSION: string;
+  readonly VITE_FLOWISE_VERSION: string;
+  readonly VITE_WEBUI_VERSION: string;
   readonly VITE_NEXTCLOUD_VERSION: string;
+  readonly VITE_WAHA_VERSION: string;
+  readonly VITE_MATRIX_VERSION: string;
+  readonly VITE_MAUBOT_VERSION: string;
   readonly VITE_BASEROW_VERSION: string;
+  readonly VITE_KEYCLOAK_VERSION: string;
+  readonly VITE_QDRANT_VERSION: string;
+  readonly VITE_JAMBONZ_VERSION: string;
+  readonly VITE_BOLT_VERSION: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- add the jambonz telephony platform to the services catalog with logo, category, and description
- provide default configuration, environment typings, and example variables for the new service
- tidy environment typings by enumerating all referenced service URLs and version variables

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca8ebbacbc832fb15d43ef3f845803